### PR TITLE
Explicitly specify the team that players land on.

### DIFF
--- a/app/handlers/matchup_selection.py
+++ b/app/handlers/matchup_selection.py
@@ -70,8 +70,8 @@ class MatchupSelectionHandlers:
         for index, matchup in enumerate(matchups):
             matchup_descriptions.append(
                 ("Option {} {}\n"
-                 "{}\n"
-                 "{}"
+                 "Team 1 (left): {}\n"
+                 "Team 2 (right): {}"
                  ).format(str(index + 1),
                           MatchupSelectionHandlers._matchup_marks(matchup),
                           ", ".join([players_map[player.id].name for player in matchup.team_1]),


### PR DESCRIPTION
It is sometimes highly confusing to figure out which team each player should join. I think by explicitly specifying the team and its position (left/right), we can make that choice clear.